### PR TITLE
fix: correct typo in cloneQemuMachine method name

### DIFF
--- a/src/http-proxmox.repository.ts
+++ b/src/http-proxmox.repository.ts
@@ -291,7 +291,7 @@ export class HttpProxmoxRepository {
     return (data as unknown as any)?.data?.data as string;
   }
 
-  async cloneQemuMarchine (payload: CloneQemuMachinePayload) {
+  async cloneQemuMachine (payload: CloneQemuMachinePayload) {
     let data;
     try {
       data = await axios({


### PR DESCRIPTION
I just spotted a typo while checking out your package and had to jump in and fix it. 👉👈